### PR TITLE
Compute Shader workgroup thread optimization

### DIFF
--- a/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/environments/IrisBufferEnvironment.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/environments/IrisBufferEnvironment.java
@@ -3,12 +3,12 @@ package com.github.argon4w.acceleratedrendering.compat.iris.environments;
 import com.github.argon4w.acceleratedrendering.compat.iris.buffers.IrisRenderType;
 import com.github.argon4w.acceleratedrendering.core.buffers.environments.IBufferEnvironment;
 import com.github.argon4w.acceleratedrendering.core.gl.buffers.IServerBuffer;
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
 import com.github.argon4w.acceleratedrendering.core.meshes.ServerMesh;
 import com.github.argon4w.acceleratedrendering.core.programs.IProgramDispatcher;
 import com.github.argon4w.acceleratedrendering.core.programs.culling.ICullingProgramSelector;
 import com.github.argon4w.acceleratedrendering.core.programs.processing.IPolygonProcessor;
 import com.github.argon4w.acceleratedrendering.core.programs.transform.ITransformProgramSelector;
+import com.github.argon4w.acceleratedrendering.core.programs.transform.TransformProgramDispatcher;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.irisshaders.iris.shaderpack.materialmap.WorldRenderingSettings;
@@ -61,7 +61,7 @@ public class IrisBufferEnvironment implements IBufferEnvironment {
     }
 
     @Override
-    public ComputeProgram selectTransformProgram() {
+    public TransformProgramDispatcher selectTransformProgram() {
         return getSubSet().selectTransformProgram();
     }
 
@@ -145,7 +145,7 @@ public class IrisBufferEnvironment implements IBufferEnvironment {
         }
 
         @Override
-        public ComputeProgram selectTransformProgram() {
+        public TransformProgramDispatcher selectTransformProgram() {
             return transformProgramSelector.select();
         }
 

--- a/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/programs/culling/IrisCullingProgramDispatcher.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/programs/culling/IrisCullingProgramDispatcher.java
@@ -27,7 +27,7 @@ public class IrisCullingProgramDispatcher implements IProgramDispatcher {
 
     @Override
     public void dispatch(VertexFormat.Mode mode, int vertexCount) {
-        uniform.upload(getModelViewMatrix());
+        uniform.uploadMatrix4fv(getModelViewMatrix());
         program.dispatch(mode.indexCount(vertexCount) / 3);
     }
 

--- a/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/programs/transform/IrisTransformProgramSelector.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/compat/iris/programs/transform/IrisTransformProgramSelector.java
@@ -1,29 +1,28 @@
 package com.github.argon4w.acceleratedrendering.compat.iris.programs.transform;
 
 import com.github.argon4w.acceleratedrendering.compat.iris.IrisCompatFeature;
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
-import com.github.argon4w.acceleratedrendering.core.programs.ComputeShaderProgramLoader;
 import com.github.argon4w.acceleratedrendering.core.programs.transform.ITransformProgramSelector;
+import com.github.argon4w.acceleratedrendering.core.programs.transform.TransformProgramDispatcher;
 import net.minecraft.resources.ResourceLocation;
 
 public class IrisTransformProgramSelector implements ITransformProgramSelector {
 
     private final ITransformProgramSelector parent;
-    private final ComputeProgram program;
+    private final TransformProgramDispatcher dispatcher;
 
-    public IrisTransformProgramSelector(ITransformProgramSelector parent, ComputeProgram program) {
+    public IrisTransformProgramSelector(ITransformProgramSelector parent, TransformProgramDispatcher dispatcher) {
         this.parent = parent;
-        this.program = program;
+        this.dispatcher = dispatcher;
     }
 
     public IrisTransformProgramSelector(ITransformProgramSelector parent, ResourceLocation key) {
-        this(parent, ComputeShaderProgramLoader.getProgram(key));
+        this(parent, new TransformProgramDispatcher(key));
     }
 
     @Override
-    public ComputeProgram select() {
+    public TransformProgramDispatcher select() {
         return IrisCompatFeature.isEnabled()
-                ? program
+                ? dispatcher
                 : parent.select();
     }
 

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/buffers/environments/IBufferEnvironment.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/buffers/environments/IBufferEnvironment.java
@@ -1,8 +1,8 @@
 package com.github.argon4w.acceleratedrendering.core.buffers.environments;
 
 import com.github.argon4w.acceleratedrendering.core.gl.buffers.IServerBuffer;
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
 import com.github.argon4w.acceleratedrendering.core.programs.IProgramDispatcher;
+import com.github.argon4w.acceleratedrendering.core.programs.transform.TransformProgramDispatcher;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
@@ -15,7 +15,7 @@ public interface IBufferEnvironment {
     void addExtraVertex(long address);
     boolean isAccelerated(VertexFormat vertexFormat);
     IServerBuffer getServerMeshBuffer();
-    ComputeProgram selectTransformProgram();
+    TransformProgramDispatcher selectTransformProgram();
     IProgramDispatcher selectCullProgramDispatcher(RenderType renderType);
     IProgramDispatcher selectProcessingProgramDispatcher(VertexFormat.Mode mode);
     RenderType getRenderType(RenderType renderType);

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/buffers/environments/VanillaBufferEnvironment.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/buffers/environments/VanillaBufferEnvironment.java
@@ -1,12 +1,12 @@
 package com.github.argon4w.acceleratedrendering.core.buffers.environments;
 
 import com.github.argon4w.acceleratedrendering.core.gl.buffers.IServerBuffer;
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
 import com.github.argon4w.acceleratedrendering.core.meshes.ServerMesh;
 import com.github.argon4w.acceleratedrendering.core.programs.EmptyProgramDispatcher;
 import com.github.argon4w.acceleratedrendering.core.programs.IProgramDispatcher;
 import com.github.argon4w.acceleratedrendering.core.programs.culling.ICullingProgramSelector;
 import com.github.argon4w.acceleratedrendering.core.programs.transform.ITransformProgramSelector;
+import com.github.argon4w.acceleratedrendering.core.programs.transform.TransformProgramDispatcher;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.blaze3d.vertex.VertexFormatElement;
 import net.minecraft.client.renderer.RenderType;
@@ -46,7 +46,7 @@ public class VanillaBufferEnvironment implements IBufferEnvironment {
     }
 
     @Override
-    public ComputeProgram selectTransformProgram() {
+    public TransformProgramDispatcher selectTransformProgram() {
         return transformProgramSelector.select();
     }
 

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/gl/programs/Uniform.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/gl/programs/Uniform.java
@@ -1,29 +1,32 @@
 package com.github.argon4w.acceleratedrendering.core.gl.programs;
 
 import org.joml.Matrix4f;
-import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.MemoryStack;
 
 import java.nio.FloatBuffer;
 
+import static org.lwjgl.opengl.GL41.glProgramUniform1ui;
 import static org.lwjgl.opengl.GL46.glProgramUniformMatrix4fv;
 
 public class Uniform {
 
     private final int programHandle;
     private final int uniformLocation;
-    private final FloatBuffer matrixBuffer;
 
     public Uniform(int programHandle, int uniformLocation) {
         this.programHandle = programHandle;
         this.uniformLocation = uniformLocation;
-        this.matrixBuffer = MemoryUtil.memCallocFloat(16);
     }
 
-    public void upload(Matrix4f matrix) {
-        glProgramUniformMatrix4fv(programHandle, uniformLocation, false, matrix.get(matrixBuffer));
+    public void uploadMatrix4fv(Matrix4f matrix) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            FloatBuffer matrixBuffer = stack.mallocFloat(16);
+            matrix.get(matrixBuffer);
+            glProgramUniformMatrix4fv(programHandle, uniformLocation, false, matrixBuffer);
+        }
     }
 
-    public void delete() {
-        MemoryUtil.memFree(matrixBuffer);
+    public void upload1ui(int value) {
+        glProgramUniform1ui(programHandle, uniformLocation, value);
     }
 }

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/FixedTransformProgramSelector.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/FixedTransformProgramSelector.java
@@ -1,26 +1,24 @@
 package com.github.argon4w.acceleratedrendering.core.programs.transform;
 
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
-import com.github.argon4w.acceleratedrendering.core.programs.ComputeShaderProgramLoader;
 import net.minecraft.resources.ResourceLocation;
 
 public class FixedTransformProgramSelector implements ITransformProgramSelector {
 
     private final ITransformProgramSelector parent;
-    private final ComputeProgram program;
+    private final TransformProgramDispatcher dispatcher;
 
-    public FixedTransformProgramSelector(ITransformProgramSelector parent, ComputeProgram program) {
+    public FixedTransformProgramSelector(ITransformProgramSelector parent, TransformProgramDispatcher dispatcher) {
         this.parent = parent;
-        this.program = program;
+        this.dispatcher = dispatcher;
     }
 
     public FixedTransformProgramSelector(ITransformProgramSelector parent, ResourceLocation key) {
-        this(parent, ComputeShaderProgramLoader.getProgram(key));
+        this(parent, new TransformProgramDispatcher(key));
     }
 
     @Override
-    public ComputeProgram select() {
-        return program;
+    public TransformProgramDispatcher select() {
+        return dispatcher;
     }
 
     @Override

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/ITransformProgramSelector.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/ITransformProgramSelector.java
@@ -1,12 +1,11 @@
 package com.github.argon4w.acceleratedrendering.core.programs.transform;
 
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.neoforged.fml.ModLoader;
 
 public interface ITransformProgramSelector {
 
-    ComputeProgram select();
+    TransformProgramDispatcher select();
     int getSharingFlags();
 
     static ITransformProgramSelector throwing() {

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/ThrowingTransformProgramSelector.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/ThrowingTransformProgramSelector.java
@@ -1,13 +1,11 @@
 package com.github.argon4w.acceleratedrendering.core.programs.transform;
 
-import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
-
 public class ThrowingTransformProgramSelector implements ITransformProgramSelector {
 
     public static final ThrowingTransformProgramSelector INSTANCE = new ThrowingTransformProgramSelector();
 
     @Override
-    public ComputeProgram select() {
+    public TransformProgramDispatcher select() {
         throw new IllegalStateException("Cannot select a valid transform program.");
     }
 

--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/TransformProgramDispatcher.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/programs/transform/TransformProgramDispatcher.java
@@ -1,0 +1,27 @@
+package com.github.argon4w.acceleratedrendering.core.programs.transform;
+
+import com.github.argon4w.acceleratedrendering.core.gl.programs.ComputeProgram;
+import com.github.argon4w.acceleratedrendering.core.gl.programs.Uniform;
+import com.github.argon4w.acceleratedrendering.core.programs.ComputeShaderProgramLoader;
+import net.minecraft.resources.ResourceLocation;
+
+public class TransformProgramDispatcher {
+    private static final int BATCH_SIZE = 128;
+
+    private final ComputeProgram program;
+    private final Uniform vertexCountUniform;
+
+    private TransformProgramDispatcher(ComputeProgram program) {
+        this.program = program;
+        this.vertexCountUniform = program.getUniform("vertexCount");
+    }
+
+    public TransformProgramDispatcher(ResourceLocation key) {
+        this(ComputeShaderProgramLoader.getProgram(key));
+    }
+
+    public void dispatch(int vertexCount) {
+        vertexCountUniform.upload1ui(vertexCount);
+        program.dispatch((vertexCount + BATCH_SIZE - 1) / BATCH_SIZE);
+    }
+}

--- a/src/main/java/com/github/argon4w/acceleratedrendering/features/culling/NormalCullingProgramDispatcher.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/features/culling/NormalCullingProgramDispatcher.java
@@ -24,7 +24,7 @@ public class NormalCullingProgramDispatcher implements IProgramDispatcher {
 
     @Override
     public void dispatch(VertexFormat.Mode mode, int vertexCount) {
-        uniform.upload(RenderSystem.getModelViewMatrix());
+        uniform.uploadMatrix4fv(RenderSystem.getModelViewMatrix());
         program.dispatch(mode.indexCount(vertexCount) / 3);
     }
 }

--- a/src/main/resources/assets/acceleratedrendering/shaders/compat/transform/iris_entity_vertex_transform_shader.compute
+++ b/src/main/resources/assets/acceleratedrendering/shaders/compat/transform/iris_entity_vertex_transform_shader.compute
@@ -1,5 +1,7 @@
 #version 460 core
 
+uniform uint vertexCount;
+
 struct Vertex {
     float x;
     float y;
@@ -34,7 +36,7 @@ struct SharingData {
     uint iris_entity_1;
 };
 
-layout(local_size_x=1, local_size_y=1) in;
+layout(local_size_x = 128) in;
 
 layout(binding=0, std430) buffer VerticesIn {
     Vertex verticesIn[];
@@ -57,7 +59,11 @@ layout(binding=4, std430) readonly buffer Mesh {
 };
 
 void main() {
-    int index = int(gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y + gl_WorkGroupID.y * gl_NumWorkGroups.x + gl_WorkGroupID.x);
+    uint index = gl_GlobalInvocationID.x;
+    if (index >= vertexCount) {
+        return;
+    }
+
     int offset = varyings[index].offset;
 
     VaryingData varyingData = varyings[index - offset];

--- a/src/main/resources/assets/acceleratedrendering/shaders/core/transform/entity_vertex_transform_shader.compute
+++ b/src/main/resources/assets/acceleratedrendering/shaders/core/transform/entity_vertex_transform_shader.compute
@@ -1,5 +1,7 @@
 #version 460 core
 
+uniform uint vertexCount;
+
 struct Vertex {
     float x;
     float y;
@@ -29,7 +31,7 @@ struct SharingData {
     uint extra_data_2;
 };
 
-layout(local_size_x=1, local_size_y=1) in;
+layout(local_size_x = 128) in;
 
 layout(binding=0, std430) buffer VerticesIn {
     Vertex verticesIn[];
@@ -52,7 +54,11 @@ layout(binding=4, std430) readonly buffer Mesh {
 };
 
 void main() {
-    int index = int(gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y + gl_WorkGroupID.y * gl_NumWorkGroups.x + gl_WorkGroupID.x);
+    uint index = gl_GlobalInvocationID.x;
+    if (index >= vertexCount) {
+        return;
+    }
+
     int offset = varyings[index].offset;
 
     VaryingData varyingData = varyings[index - offset];


### PR DESCRIPTION
Change vertex transform compute shader workgroup size to 128 threads. Other compute shaders remain the same.
See #3 

~80% faster compute pass
![83aad261c148415e45eb196444c94e66](https://github.com/user-attachments/assets/3fa05268-209b-4ee3-ad87-0c57f0e59ee9)
