### PR TITLE
Fixed GL debug messages kept showing in the log

### DIFF
--- a/src/main/java/com/github/argon4w/acceleratedrendering/core/backends/buffers/ImmutableBuffer.java
+++ b/src/main/java/com/github/argon4w/acceleratedrendering/core/backends/buffers/ImmutableBuffer.java
@@ -92,7 +92,7 @@ public class ImmutableBuffer implements IServerBuffer {
                 GL_R8UI,
                 offset,
                 size,
-                GL_RED,
+                GL_RED_INTEGER,
                 GL_UNSIGNED_BYTE,
                 (ByteBuffer) null
         );


### PR DESCRIPTION
Fixes `OpenGL debug message: id=2, source=API, type=ERROR, severity=HIGH, message='GL_INVALID_OPERATION in glClearNamedBufferSubData(integer vs non-integer)'` being shown in the log.

Tested & everything working fine, just a one-line change.