### PR TITLE
Fix `Permission denied` in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Grant Premission
+        run: chmod +x ./gradlew
+
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
Added a step to grant execute permission to gradlew.

Should fix [this](https://github.com/Argon4W/AcceleratedRendering/actions/runs/18449246643/job/52560456420):
```
/home/runner/work/_temp/df933347-f8be-44d7-aeb5-80dbc4beba1f.sh: line 1: ./gradlew: Permission denied
```